### PR TITLE
Added method for moving relative position

### DIFF
--- a/src/slider.ts
+++ b/src/slider.ts
@@ -219,6 +219,27 @@ class CreateSlider {
     }
   }
 
+  setRelativePosition = (x: number): void => {
+    // Set new relative slider, moving it `x` distance
+    this.x = this.sliderTag.offsetLeft - x
+    this.startX = this.sliderTag.offsetLeft
+    this.scrollLeft = this.scrollAmount
+    this.dist = this.scrollLeft - (this.x - this.startX) * this.dragSpeed
+
+    // Guards: Can't go over the slider
+    if (this.dist + this.scrollAmount <= 0) return
+    if (this.dist >= this.scrollWidth) return
+
+    // Set slider active class
+    this.sliderTag.classList.add('active')
+
+    // Animate and transform
+    this.anime()
+
+    // Remove slider active class
+    this.sliderTag.classList.remove('active')
+  }
+
   init = (): void => {
     this.isAnimating = false
     this.stopAnimation = false


### PR DESCRIPTION
Hey, so I had some time to fiddle around with this. I think this is working alright, but I'm super open to feedback. All told this is a simple little add on to move the slider's transform position relative to its current position.

So, if I wanted to bump the slider over 400px to the right I could do as follows:

```js
import { CreateSlider } from 'bundle.esm';

const mySlider = new CreateSlider({
  container: '.slider',
  slider: '.slides'
});

// Shift the position of the slider 400px to the right
document.querySelector("#next-button").addEventListener("click", ()  => mySlider.setRelativePosition(400));
document.querySelector("#prev-button").addEventListener("click", ()  => mySlider.setRelativePosition(-400));
```